### PR TITLE
feat: make SVG textures usable as textures directly

### DIFF
--- a/Source/SvgBooga/Private/SvgTexture2D.cpp
+++ b/Source/SvgBooga/Private/SvgTexture2D.cpp
@@ -305,6 +305,9 @@ void USvgTexture2D::UpdateResource() {
 	Texture->UpdateResource();
 	Super::UpdateResource();
 }
+EMaterialValueType USvgTexture2D::GetMaterialType() const {
+	return Texture->GetMaterialType();
+}
 
 //#region for UStreamableRenderAsset
 bool USvgTexture2D::StreamOut(int32 NewMipCount)

--- a/Source/SvgBooga/Private/SvgTexture2D.cpp
+++ b/Source/SvgBooga/Private/SvgTexture2D.cpp
@@ -237,6 +237,10 @@ float USvgTexture2D::GetAspectRatio()
 //#region For UTexture
 FTextureResource* USvgTexture2D::CreateResource() {
 	UE_LOG(LogTemp, Warning, TEXT("USvgTexture2D::CreateResource()"));
+	if (!Texture->IsAsyncCacheComplete()) {
+		UE_LOG(LogTemp, Warning, TEXT("USvgTexture2D::CreateResource(): cache not completed"));
+		Texture->BlockOnAnyAsyncBuild();
+	}
 	FTextureResource* TextureResource = Texture->CreateResource();
 	UE_LOG(LogTemp, Warning, TEXT("USvgTexture2D::CreateResource() done"));
 	return TextureResource;
@@ -264,11 +268,11 @@ void USvgTexture2D::PreSave(FObjectPreSaveContext ObjectSaveContext) {
 	Texture->PreSave(ObjectSaveContext);
 }
 bool USvgTexture2D::IsReadyForAsyncPostLoad() const {
-	bool bReady = Texture->IsReadyForAsyncPostLoad();
+	bool Ready = Texture->IsReadyForAsyncPostLoad();
 	UE_LOG(LogTemp, Warning,
 		TEXT("USvgTexture2D::IsReadyForAsyncPostLoad(): ready: %d"),
-		bReady);
-	return bReady;
+		Ready);
+	return Ready;
 }
 void USvgTexture2D::PostLoad() {
 	UE_LOG(LogTemp, Warning, TEXT("USvgTexture2D::PostLoad()"));
@@ -283,11 +287,36 @@ bool USvgTexture2D::IsCompiling() const {
 		Compiling);
 	return Compiling;
 }
+bool USvgTexture2D::IsDefaultTexture() const
+{
+	bool IsDefaultTexture = Texture->IsDefaultTexture();
+	UE_LOG(LogTemp, Warning,
+		TEXT("USvgTexture2D::IsDefaultTexture(): %d"),
+		IsDefaultTexture);
+	return IsDefaultTexture;
+}
+void USvgTexture2D::BeginCacheForCookedPlatformData(const ITargetPlatform* TargetPlatform) {
+	UE_LOG(LogTemp, Warning, TEXT("USvgTexture2D::BeginCacheForCookedPlatformData()"));
+	Texture->BeginCacheForCookedPlatformData(TargetPlatform);
+}
+bool USvgTexture2D::IsCachedCookedPlatformDataLoaded(const ITargetPlatform* TargetPlatform) {
+	UE_LOG(LogTemp, Warning, TEXT("USvgTexture2D::IsCachedCookedPlatformDataLoaded()"));
+	return Texture->IsCachedCookedPlatformDataLoaded(TargetPlatform);
+}
+void USvgTexture2D::ClearCachedCookedPlatformData(const ITargetPlatform* TargetPlatform) {
+	UE_LOG(LogTemp, Warning, TEXT("USvgTexture2D::ClearCachedCookedPlatformData()"));
+	Texture->ClearCachedCookedPlatformData(TargetPlatform);
+}
+void USvgTexture2D::ClearAllCachedCookedPlatformData() {
+	UE_LOG(LogTemp, Warning, TEXT("USvgTexture2D::ClearAllCachedCookedPlatformData()"));
+	Texture->ClearAllCachedCookedPlatformData();
+}
+
 bool USvgTexture2D::IsCurrentlyVirtualTextured() const {
 	bool VirtuallyTextured = Texture->IsCurrentlyVirtualTextured();
-	UE_LOG(LogTemp, Warning,
+	/*UE_LOG(LogTemp, Warning,
 		TEXT("USvgTexture2D::IsCurrentlyVirtualTextured(): %d"),
-		VirtuallyTextured);
+		VirtuallyTextured);*/
 	return VirtuallyTextured;
 }
 void USvgTexture2D::UpdateResource() {
@@ -295,6 +324,16 @@ void USvgTexture2D::UpdateResource() {
 	Texture->UpdateResource();
 	Super::UpdateResource();
 }
+void USvgTexture2D::BlockOnAnyAsyncBuild()
+{
+	UE_LOG(LogTemp, Warning, TEXT("USvgTexture2D::BlockOnAnyAsyncBuild()"));
+	Texture->BlockOnAnyAsyncBuild();
+}
+//FTexturePlatformData** USvgTexture2D::GetRunningPlatformData()
+//{
+//	UE_LOG(LogTemp, Warning, TEXT("USvgTexture2D::GetRunningPlatformData()"));
+//	return Texture->GetRunningPlatformData();
+//}
 
 //#region for UStreamableRenderAsset
 bool USvgTexture2D::StreamOut(int32 NewMipCount)

--- a/Source/SvgBooga/Private/SvgTexture2D.cpp
+++ b/Source/SvgBooga/Private/SvgTexture2D.cpp
@@ -237,10 +237,12 @@ float USvgTexture2D::GetAspectRatio()
 //#region For UTexture
 FTextureResource* USvgTexture2D::CreateResource() {
 	UE_LOG(LogTemp, Warning, TEXT("USvgTexture2D::CreateResource()"));
+#if WITH_EDITOR
 	if (!Texture->IsAsyncCacheComplete()) {
 		UE_LOG(LogTemp, Warning, TEXT("USvgTexture2D::CreateResource(): cache not completed"));
 		Texture->BlockOnAnyAsyncBuild();
 	}
+#endif
 	FTextureResource* TextureResource = Texture->CreateResource();
 	UE_LOG(LogTemp, Warning, TEXT("USvgTexture2D::CreateResource() done"));
 	return TextureResource;
@@ -280,6 +282,7 @@ void USvgTexture2D::PostLoad() {
 	Super::PostLoad();
 }
 
+#if WITH_EDITOR
 bool USvgTexture2D::IsCompiling() const {
 	bool Compiling = Texture->IsCompiling();
 	UE_LOG(LogTemp, Warning,
@@ -295,6 +298,7 @@ bool USvgTexture2D::IsDefaultTexture() const
 		IsDefaultTexture);
 	return IsDefaultTexture;
 }
+#endif
 
 bool USvgTexture2D::IsCurrentlyVirtualTextured() const {
 	bool VirtuallyTextured = Texture->IsCurrentlyVirtualTextured();

--- a/Source/SvgBooga/Private/SvgTexture2D.cpp
+++ b/Source/SvgBooga/Private/SvgTexture2D.cpp
@@ -21,7 +21,7 @@ uint32 ConvertFLinearColorToInteger(const FLinearColor& Color)
 USvgTexture2D::USvgTexture2D(const FObjectInitializer& ObjectInitializer)
 	: Super(ObjectInitializer)
 {
-	UE_LOG(LogTemp, Warning, TEXT("SvgBooga: USvgTexture2D(ObjectInitializer)"));
+	UE_LOG(LogTemp, Warning, TEXT("USvgTexture2D(ObjectInitializer)"));
 	Texture = ObjectInitializer.CreateDefaultSubobject<UTexture2D>(this, TEXT("Texture"));
 }
 
@@ -29,12 +29,12 @@ USvgTexture2D::USvgTexture2D(const FObjectInitializer& ObjectInitializer)
 bool USvgTexture2D::UpdateTextureFromSvg(const FString& SvgFilePath, const int TextureWidth, const int TextureHeight,
                                          const FLinearColor InBackgroundColor = FLinearColor::Transparent)
 {
-	UE_LOG(LogTemp, Warning, TEXT("SvgBooga: USvgTexture2D::UpdateTextureFromSvg()"));
+	UE_LOG(LogTemp, Warning, TEXT("USvgTexture2D::UpdateTextureFromSvg()"));
 	BackgroundColor = InBackgroundColor;
 	const std::unique_ptr<lunasvg::Document> Document = lunasvg::Document::loadFromFile(TCHAR_TO_UTF8(*SvgFilePath));
 	if (!Document)
 	{
-		UE_LOG(LogTemp, Error, TEXT("SvgBooga: Failed to load SVG file: %s"), *SvgFilePath);
+		UE_LOG(LogTemp, Error, TEXT("Failed to load SVG file: %s"), *SvgFilePath);
 		return false;
 	}
 
@@ -60,7 +60,7 @@ bool USvgTexture2D::UpdateTextureFromSvg(const FString& SvgFilePath, const int T
 	                                                        ConvertFLinearColorToInteger(BackgroundColor));
 	if (!Bitmap.valid())
 	{
-		UE_LOG(LogTemp, Error, TEXT("SvgBooga: Failed to render SVG to bitmap."));
+		UE_LOG(LogTemp, Error, TEXT("Failed to render SVG to bitmap."));
 		return false;
 	}
 
@@ -70,7 +70,7 @@ bool USvgTexture2D::UpdateTextureFromSvg(const FString& SvgFilePath, const int T
 
 TSharedPtr<FImage> USvgTexture2D::ConvertBitmapToImage(const lunasvg::Bitmap& Bitmap)
 {
-	UE_LOG(LogTemp, Warning, TEXT("SvgBooga: USvgTexture2D::ConvertBitmapToImage()"));
+	UE_LOG(LogTemp, Warning, TEXT("USvgTexture2D::ConvertBitmapToImage()"));
 	TSharedPtr<FImage> Image = MakeShared<FImage>();
 	if (!Bitmap.valid())
 	{
@@ -109,22 +109,22 @@ TSharedPtr<FImage> USvgTexture2D::ConvertBitmapToImage(const lunasvg::Bitmap& Bi
 void USvgTexture2D::UpdateTextureFromImage(const TSharedPtr<FImage>& SourceImage, const int TextureWidth,
                                            const int TextureHeight)
 {
-	UE_LOG(LogTemp, Warning, TEXT("SvgBooga: USvgTexture2D::UpdateTextureFromImage()"));
+	UE_LOG(LogTemp, Warning, TEXT("USvgTexture2D::UpdateTextureFromImage()"));
 	if (!IsInGameThread())
 	{
-		UE_LOG(LogTemp, Error, TEXT("SvgBooga: UpdateTextureFromImage must be called on the game thread."));
+		UE_LOG(LogTemp, Error, TEXT("UpdateTextureFromImage must be called on the game thread."));
 		return;
 	}
 
 	if (!SourceImage)
 	{
-		UE_LOG(LogTemp, Error, TEXT("SvgBooga: SourceImage is not valid."));
+		UE_LOG(LogTemp, Error, TEXT("SourceImage is not valid."));
 		return;
 	}
 
 	if (!Texture)
 	{
-		UE_LOG(LogTemp, Error, TEXT("SvgBooga: Texture is not initialized."));
+		UE_LOG(LogTemp, Error, TEXT("Texture is not initialized."));
 		return;
 	}
 
@@ -183,7 +183,7 @@ void USvgTexture2D::UpdateTextureFromImage(const TSharedPtr<FImage>& SourceImage
 	}
 	else
 	{
-		UE_LOG(LogTemp, Error, TEXT("SvgBooga: Failed to lock MipMap data for writing."));
+		UE_LOG(LogTemp, Error, TEXT("Failed to lock MipMap data for writing."));
 		return;
 	}
 
@@ -199,14 +199,9 @@ void USvgTexture2D::UpdateTextureFromBitmap(const lunasvg::Bitmap& Bitmap, const
 }
 #endif
 
-inline int32 MipsCount(USvgTexture2D *SvgTexture) {
-	return SvgTexture->GetTexture()->GetPlatformData() == nullptr ? -1 :
-		SvgTexture->GetTexture()->GetPlatformData()->Mips.Num();
-}
-
 void USvgTexture2D::Serialize(FArchive& Ar)
 {
-	UE_LOG(LogTemp, Warning, TEXT("SvgBooga: USvgTexture2D::Serialize() in mode %s"), Ar.IsSaving() ? TEXT("Save") : Ar.IsLoading() ? TEXT("Load") : TEXT("Other"));
+	UE_LOG(LogTemp, Warning, TEXT("USvgTexture2D::Serialize()"));
 	Super::Serialize(Ar);
 
 	Ar << OriginalWidth;
@@ -214,13 +209,7 @@ void USvgTexture2D::Serialize(FArchive& Ar)
 	Ar << ImportPath;
 	Ar << AspectRatio;
 	Ar << BackgroundColor;
-	UE_LOG(LogTemp, Warning,
-		TEXT("SvgBooga: USvgTexture2D::Serialize(): num mips before: %d"),
-		MipsCount(this));
 	Ar << Texture;
-	UE_LOG(LogTemp, Warning,
-		TEXT("SvgBooga: USvgTexture2D::Serialize(): num mips after: %d"),
-		MipsCount(this));
 }
 
 UTexture2D* USvgTexture2D::GetTexture()
@@ -247,12 +236,9 @@ float USvgTexture2D::GetAspectRatio()
 
 //#region For UTexture
 FTextureResource* USvgTexture2D::CreateResource() {
-	UE_LOG(LogTemp, Warning, TEXT("SvgBooga: USvgTexture2D::CreateResource()"));
+	UE_LOG(LogTemp, Warning, TEXT("USvgTexture2D::CreateResource()"));
 	FTextureResource* TextureResource = Texture->CreateResource();
-	UE_LOG(LogTemp, Warning, TEXT("SvgBooga: TextureResource obtained."));
-	UE_LOG(LogTemp, Warning,
-		TEXT("SvgBooga: USvgTexture2D::CreateResource(): num mips after: %d (%d)"),
-		MipsCount(this), TextureResource->GetCurrentMipCount());
+	UE_LOG(LogTemp, Warning, TEXT("USvgTexture2D::CreateResource() done"));
 	return TextureResource;
 }
 
@@ -273,56 +259,41 @@ uint32 USvgTexture2D::GetSurfaceArraySize() const {
 	return Texture->GetSurfaceArraySize();
 }
 void USvgTexture2D::PreSave(FObjectPreSaveContext ObjectSaveContext) {
-	UE_LOG(LogTemp, Warning,
-		TEXT("SvgBooga: USvgTexture2D::PreSave(): num mips after: %d"),
-		MipsCount(this));
+	UE_LOG(LogTemp, Warning, TEXT("USvgTexture2D::PreSave()"));
 	Super::PreSave(ObjectSaveContext);
 	Texture->PreSave(ObjectSaveContext);
-	UE_LOG(LogTemp, Warning,
-		TEXT("SvgBooga: USvgTexture2D::PreSave(): num mips after: %d"),
-		MipsCount(this));
 }
 bool USvgTexture2D::IsReadyForAsyncPostLoad() const {
-	bool bReady =  Texture->IsReadyForAsyncPostLoad();
+	bool bReady = Texture->IsReadyForAsyncPostLoad();
 	UE_LOG(LogTemp, Warning,
-		TEXT("SvgBooga: USvgTexture2D::IsReadyForAsyncPostLoad(): ret val: %d"),
+		TEXT("USvgTexture2D::IsReadyForAsyncPostLoad(): ready: %d"),
 		bReady);
 	return bReady;
 }
 void USvgTexture2D::PostLoad() {
-	UE_LOG(LogTemp, Warning,
-		TEXT("SvgBooga: USvgTexture2D::PostLoad(): num mips before: %d"),
-		MipsCount(this));
+	UE_LOG(LogTemp, Warning, TEXT("USvgTexture2D::PostLoad()"));
 	Texture->PostLoad();
 	Super::PostLoad();
-	UE_LOG(LogTemp, Warning,
-		TEXT("SvgBooga: USvgTexture2D::PostLoad(): num mips after: %d"),
-		MipsCount(this));
 }
 
 bool USvgTexture2D::IsCompiling() const {
 	bool Compiling = Texture->IsCompiling();
 	UE_LOG(LogTemp, Warning,
-		TEXT("SvgBooga: USvgTexture2D::IsCompiling(): compiling: %d"),
+		TEXT("USvgTexture2D::IsCompiling(): compiling: %d"),
 		Compiling);
 	return Compiling;
 }
 bool USvgTexture2D::IsCurrentlyVirtualTextured() const {
 	bool VirtuallyTextured = Texture->IsCurrentlyVirtualTextured();
 	UE_LOG(LogTemp, Warning,
-		TEXT("SvgBooga: USvgTexture2D::IsCurrentlyVirtualTextured(): %d"),
+		TEXT("USvgTexture2D::IsCurrentlyVirtualTextured(): %d"),
 		VirtuallyTextured);
 	return VirtuallyTextured;
 }
 void USvgTexture2D::UpdateResource() {
-	UE_LOG(LogTemp, Warning,
-		TEXT("SvgBooga: USvgTexture2D::UpdateResource(): num mips before: %d"),
-		MipsCount(this));
+	UE_LOG(LogTemp, Warning, TEXT("USvgTexture2D::UpdateResource()"));
 	Texture->UpdateResource();
 	Super::UpdateResource();
-	UE_LOG(LogTemp, Warning,
-		TEXT("SvgBooga: USvgTexture2D::UpdateResource(): num mips after: %d"),
-		MipsCount(this));
 }
 
 //#region for UStreamableRenderAsset

--- a/Source/SvgBooga/Private/SvgTexture2D.cpp
+++ b/Source/SvgBooga/Private/SvgTexture2D.cpp
@@ -1,4 +1,4 @@
-﻿#include "SvgTexture2D.h"
+#include "SvgTexture2D.h"
 
 #include "ImageUtils.h"
 #if WITH_EDITOR
@@ -241,50 +241,7 @@ FTextureResource* USvgTexture2D::CreateResource() {
 
 int32 USvgTexture2D::CalcCumulativeLODSize(int32 MipCount) const
 {
-	//return Texture->MaxTextureSize;
-	int32 Size = 0;
-	if (Texture->GetPlatformData())
-	{
-		static TConsoleVariableData<int32>* CVarReducedMode = IConsoleManager::Get().FindTConsoleVariableDataInt(TEXT("r.VirtualTextureReducedMemory"));
-		check(CVarReducedMode);
-
-		ETextureCreateFlags TexCreateFlags = (SRGB ? TexCreate_SRGB : TexCreate_None) | (bNoTiling ? TexCreate_NoTiling : TexCreate_None) | (bNotOfflineProcessed ? TexCreate_None : TexCreate_OfflineProcessed) | TexCreate_Streamable;
-		const bool bCanUsePartiallyResidentMips = CanCreateWithPartiallyResidentMips(TexCreateFlags);
-
-		const int32 SizeX = Texture->GetSizeX();
-		const int32 SizeY = Texture->GetSizeY();
-		const int32 NumMips = Texture->GetNumMips();
-		const int32 FirstMip = FMath::Max(0, NumMips - MipCount);
-		const EPixelFormat Format = Texture->GetPixelFormat();
-
-		// Must be consistent with the logic in FTexture2DResource::InitRHI
-		/*if (Texture->IsStreamable() && bCanUsePartiallyResidentMips && (!CVarReducedMode->GetValueOnAnyThread() || MipCount > Texture->GetMinTextureResidentMipCount()))
-		{
-			TexCreateFlags |= TexCreate_Virtual;
-			Size = (int32)RHICalcVMTexture2DPlatformSize(SizeX, SizeY, Format, NumMips, FirstMip, 1, TexCreateFlags, TextureAlign);
-		}
-		else
-		{*/
-			const FIntPoint MipExtents = CalcMipMapExtent(SizeX, SizeY, Format, FirstMip);
-			const FRHIResourceCreateInfo CreateInfo(Texture->GetPlatformData()->GetExtData());
-			FRHITextureDesc Desc(
-				ETextureDimension::Texture2D,
-				TexCreateFlags,
-				(EPixelFormat)Format,
-				CreateInfo.ClearValueBinding,
-				{ (int32)SizeX, (int32)SizeY },
-				1,
-				1,
-				(uint8)FMath::Max(1, MipCount),
-				(uint8)1,
-				CreateInfo.ExtData
-			);
-			FDynamicRHI::FRHICalcTextureSizeResult PlatformSize = RHICalcTexturePlatformSize(Desc, 0);
-			Size = (int32)PlatformSize.Size;
-			//MipExtents.X, MipExtents.Y, Format, FMath::Max(1, MipCount), 1, TexCreateFlags, FRHIResourceCreateInfo(Texture->GetPlatformData()->GetExtData()), TextureAlign);
-		//}
-	}
-	return Size;
+	return -1;
 }
 float USvgTexture2D::GetSurfaceWidth() const {
 	return Texture->GetSurfaceWidth();

--- a/Source/SvgBooga/Private/SvgTexture2D.cpp
+++ b/Source/SvgBooga/Private/SvgTexture2D.cpp
@@ -295,28 +295,9 @@ bool USvgTexture2D::IsDefaultTexture() const
 		IsDefaultTexture);
 	return IsDefaultTexture;
 }
-void USvgTexture2D::BeginCacheForCookedPlatformData(const ITargetPlatform* TargetPlatform) {
-	UE_LOG(LogTemp, Warning, TEXT("USvgTexture2D::BeginCacheForCookedPlatformData()"));
-	Texture->BeginCacheForCookedPlatformData(TargetPlatform);
-}
-bool USvgTexture2D::IsCachedCookedPlatformDataLoaded(const ITargetPlatform* TargetPlatform) {
-	UE_LOG(LogTemp, Warning, TEXT("USvgTexture2D::IsCachedCookedPlatformDataLoaded()"));
-	return Texture->IsCachedCookedPlatformDataLoaded(TargetPlatform);
-}
-void USvgTexture2D::ClearCachedCookedPlatformData(const ITargetPlatform* TargetPlatform) {
-	UE_LOG(LogTemp, Warning, TEXT("USvgTexture2D::ClearCachedCookedPlatformData()"));
-	Texture->ClearCachedCookedPlatformData(TargetPlatform);
-}
-void USvgTexture2D::ClearAllCachedCookedPlatformData() {
-	UE_LOG(LogTemp, Warning, TEXT("USvgTexture2D::ClearAllCachedCookedPlatformData()"));
-	Texture->ClearAllCachedCookedPlatformData();
-}
 
 bool USvgTexture2D::IsCurrentlyVirtualTextured() const {
 	bool VirtuallyTextured = Texture->IsCurrentlyVirtualTextured();
-	/*UE_LOG(LogTemp, Warning,
-		TEXT("USvgTexture2D::IsCurrentlyVirtualTextured(): %d"),
-		VirtuallyTextured);*/
 	return VirtuallyTextured;
 }
 void USvgTexture2D::UpdateResource() {
@@ -324,16 +305,6 @@ void USvgTexture2D::UpdateResource() {
 	Texture->UpdateResource();
 	Super::UpdateResource();
 }
-void USvgTexture2D::BlockOnAnyAsyncBuild()
-{
-	UE_LOG(LogTemp, Warning, TEXT("USvgTexture2D::BlockOnAnyAsyncBuild()"));
-	Texture->BlockOnAnyAsyncBuild();
-}
-//FTexturePlatformData** USvgTexture2D::GetRunningPlatformData()
-//{
-//	UE_LOG(LogTemp, Warning, TEXT("USvgTexture2D::GetRunningPlatformData()"));
-//	return Texture->GetRunningPlatformData();
-//}
 
 //#region for UStreamableRenderAsset
 bool USvgTexture2D::StreamOut(int32 NewMipCount)

--- a/Source/SvgBooga/Public/SvgTexture2D.h
+++ b/Source/SvgBooga/Public/SvgTexture2D.h
@@ -81,8 +81,10 @@ public:
 	virtual void PreSave(FObjectPreSaveContext ObjectSaveContext) override;
 	virtual bool IsReadyForAsyncPostLoad() const override;
 	virtual void PostLoad() override;
+#if WITH_EDITOR
 	virtual bool IsCompiling() const override;
 	virtual bool IsDefaultTexture() const override;
+#endif
 	virtual bool IsCurrentlyVirtualTextured() const override;
 	virtual void UpdateResource() override;
 	virtual EMaterialValueType GetMaterialType() const override;

--- a/Source/SvgBooga/Public/SvgTexture2D.h
+++ b/Source/SvgBooga/Public/SvgTexture2D.h
@@ -82,8 +82,14 @@ public:
 	virtual bool IsReadyForAsyncPostLoad() const override;
 	virtual void PostLoad() override;
 	virtual bool IsCompiling() const override;
+	virtual bool IsDefaultTexture() const override;
+	virtual void BeginCacheForCookedPlatformData(const ITargetPlatform* TargetPlatform) override;
+	virtual bool IsCachedCookedPlatformDataLoaded(const ITargetPlatform* TargetPlatform) override;
+	virtual void ClearCachedCookedPlatformData(const ITargetPlatform* TargetPlatform) override;
+	virtual void ClearAllCachedCookedPlatformData() override;
 	virtual bool IsCurrentlyVirtualTextured() const override;
 	virtual void UpdateResource() override;
+	virtual void BlockOnAnyAsyncBuild() override;
 	//#region for UStreamableRenderAsset
 	virtual bool StreamOut(int32 NewMipCount) override;
 	virtual bool StreamIn(int32 NewMipCount, bool bHighPrio) override;

--- a/Source/SvgBooga/Public/SvgTexture2D.h
+++ b/Source/SvgBooga/Public/SvgTexture2D.h
@@ -85,6 +85,7 @@ public:
 	virtual bool IsDefaultTexture() const override;
 	virtual bool IsCurrentlyVirtualTextured() const override;
 	virtual void UpdateResource() override;
+	virtual EMaterialValueType GetMaterialType() const override;
 	//#region for UStreamableRenderAsset
 	virtual bool StreamOut(int32 NewMipCount) override;
 	virtual bool StreamIn(int32 NewMipCount, bool bHighPrio) override;

--- a/Source/SvgBooga/Public/SvgTexture2D.h
+++ b/Source/SvgBooga/Public/SvgTexture2D.h
@@ -83,13 +83,8 @@ public:
 	virtual void PostLoad() override;
 	virtual bool IsCompiling() const override;
 	virtual bool IsDefaultTexture() const override;
-	virtual void BeginCacheForCookedPlatformData(const ITargetPlatform* TargetPlatform) override;
-	virtual bool IsCachedCookedPlatformDataLoaded(const ITargetPlatform* TargetPlatform) override;
-	virtual void ClearCachedCookedPlatformData(const ITargetPlatform* TargetPlatform) override;
-	virtual void ClearAllCachedCookedPlatformData() override;
 	virtual bool IsCurrentlyVirtualTextured() const override;
 	virtual void UpdateResource() override;
-	virtual void BlockOnAnyAsyncBuild() override;
 	//#region for UStreamableRenderAsset
 	virtual bool StreamOut(int32 NewMipCount) override;
 	virtual bool StreamIn(int32 NewMipCount, bool bHighPrio) override;

--- a/Source/SvgBooga/Public/SvgTexture2D.h
+++ b/Source/SvgBooga/Public/SvgTexture2D.h
@@ -13,7 +13,7 @@ namespace lunasvg
 }
 
 UCLASS(BlueprintType)
-class SVGBOOGA_API USvgTexture2D : public UObject
+class SVGBOOGA_API USvgTexture2D : public UTexture
 {
 	GENERATED_BODY()
 
@@ -68,5 +68,18 @@ protected:
 #endif
 
 	virtual void Serialize(FArchive& Ar) override;
-	void RecreateTexture();
+
+public:
+	//#region For UTexture
+	virtual FTextureResource* CreateResource() override;
+	virtual int32 CalcCumulativeLODSize(int32 NumLODs) const final override;
+	virtual float GetSurfaceWidth() const override;
+	virtual float GetSurfaceHeight() const override;
+	virtual float GetSurfaceDepth() const override;
+	virtual uint32 GetSurfaceArraySize() const override;
+	//#region for UStreamableRenderAsset
+	virtual bool StreamOut(int32 NewMipCount) override;
+	virtual bool StreamIn(int32 NewMipCount, bool bHighPrio) override;
+	//#endregion
+	//#endregion
 };

--- a/Source/SvgBooga/Public/SvgTexture2D.h
+++ b/Source/SvgBooga/Public/SvgTexture2D.h
@@ -3,6 +3,7 @@
 #include "CoreMinimal.h"
 #include "UObject/ObjectMacros.h"
 #include "UObject/Object.h"
+#include "UObject/ObjectSaveContext.h"
 #include "Engine/Texture2D.h"
 #include "Templates/SharedPointer.h"
 #include "SvgTexture2D.generated.h"
@@ -77,6 +78,12 @@ public:
 	virtual float GetSurfaceHeight() const override;
 	virtual float GetSurfaceDepth() const override;
 	virtual uint32 GetSurfaceArraySize() const override;
+	virtual void PreSave(FObjectPreSaveContext ObjectSaveContext) override;
+	virtual bool IsReadyForAsyncPostLoad() const override;
+	virtual void PostLoad() override;
+	virtual bool IsCompiling() const override;
+	virtual bool IsCurrentlyVirtualTextured() const override;
+	virtual void UpdateResource() override;
 	//#region for UStreamableRenderAsset
 	virtual bool StreamOut(int32 NewMipCount) override;
 	virtual bool StreamIn(int32 NewMipCount, bool bHighPrio) override;

--- a/Source/SvgBooga/SvgBooga.Build.cs
+++ b/Source/SvgBooga/SvgBooga.Build.cs
@@ -29,7 +29,10 @@ public class SvgBooga : ModuleRules
 				"CoreUObject",
 				"LunaSvg",
 				"Engine",
-				"ImageCore"
+				"ImageCore",
+
+				"RenderCore",
+                "Renderer",
 				// ... add other public dependencies that you statically link with here ...
 			}
 		);


### PR DESCRIPTION
This PR makes USvgTexture inherit from texture, with all required methods proxied to the underlying `Texture` instance property.

I tested it with UI widgets, and it works well. 